### PR TITLE
[cksum] concurrent --check and other GNU options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ syntax into equivalent Go code. Code can
 
 ## Busybox-like command line tool
 
-Can be built and run like busybox or a toybox.
+Can be built and executed like busybox or a toybox.
 
 ```sh
 ./gonix cat /etc/passwd /etc/resolv.conf | md5sum
@@ -95,7 +95,7 @@ Can be built and run like busybox or a toybox.
 # Builtins
 
  * cat -uses [goawk](https://github.com/benhoyt/goawk)
- * cksum - POSIX ctx, md5 and sha checksums
+ * cksum - POSIX ctx, md5 and sha check sums, runs concurrently by default
  * wc - word count
  * head -n/--lines - uses [goawk](https://github.com/gomoni/gonix/blob/main/head/head_negative.awk)
  

--- a/TODO.md
+++ b/TODO.md
@@ -19,4 +19,5 @@
  * Add sort --version-sort
  * Add (a basic) grep
  * Add wrapper for goawk
+ * https://github.com/itchyny/gojq
  * check if we can transform things from u-root

--- a/cksum/cksum.go
+++ b/cksum/cksum.go
@@ -337,7 +337,7 @@ func (c CKSum) checkSum(ctx context.Context, stdio pipe.Stdio, debug *log.Logger
 		}
 
 		if ret != 0 {
-			return pipe.NewError(ret, err)
+			return pipe.NewError(ret, retErr)
 		}
 		return nil
 	}

--- a/cksum/cksum.go
+++ b/cksum/cksum.go
@@ -681,7 +681,7 @@ func (c CKSum) checkLine(line string, debug *log.Logger) (checkResult, error) {
 		return zero, badLineFormatErrorf("unsupported --algorithm tag %q", tag)
 	}
 
-	if c.algorithm != NONE && strings.ToUpper(c.algorithm.String()) != strings.ToUpper(tag) {
+	if c.algorithm != NONE && !strings.EqualFold(c.algorithm.String(), tag) {
 		return zero, badLineFormatErrorf("line tag %q does not match --algorithm %q", tag, c.algorithm.String())
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,10 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/pmap.go
+++ b/internal/pmap.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Michal Vyskocil. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/sync/semaphore"
+)
+
+// an experiments with a paralelization of work
+// the must is that task must maintain the order they were submitted
+
+type MapFunc[T any, U any] func(context.Context, T) (U, error)
+
+func PMap[T any, U any](ctx context.Context, limit uint, slice []T, mapFunc MapFunc[T, U]) ([]U, error) {
+	retu := make([]U, len(slice))
+	errs := make([]error, len(slice))
+
+	sem := semaphore.NewWeighted(int64(limit))
+
+	for idx, input := range slice {
+
+		if err := sem.Acquire(ctx, 1); err != nil {
+			return nil, err
+		}
+
+		go func(ctx context.Context, idx int, input T, results []U, errors []error) {
+			defer sem.Release(1)
+
+			result, err := mapFunc(ctx, input)
+			if err != nil {
+				errs[idx] = err
+			}
+			results[idx] = result
+		}(ctx, idx, input, retu, errs)
+	}
+
+	if err := sem.Acquire(ctx, int64(limit)); err != nil {
+		return nil, err
+	}
+
+	var err error
+	for _, e := range errs {
+		if e != nil {
+			err = multierror.Append(e)
+		}
+	}
+	return retu, err
+}

--- a/internal/pmap_test.go
+++ b/internal/pmap_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Michal Vyskocil. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+package internal_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/gomoni/gonix/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPMap(t *testing.T) {
+	t.Parallel()
+	f := func(_ context.Context, i int) (int, error) {
+		t.Logf("TestPMAP.f(%d)", i)
+		time.Sleep(time.Duration(i) * time.Millisecond)
+		return i + 42, nil
+	}
+	ctx := context.TODO()
+
+	start := time.Now()
+	ret, err := PMap(ctx, 1, []int{10, 20, 50, 100, 200, 500}, f)
+	stop := time.Now()
+	require.NoError(t, err)
+	require.Equal(t, []int{52, 62, 92, 142, 242, 542}, ret)
+	duration1 := stop.Sub(start)
+
+	start = time.Now()
+	ret, err = PMap(ctx, 3, []int{10, 20, 50, 100, 200, 500}, f)
+	stop = time.Now()
+	require.NoError(t, err)
+	require.Equal(t, []int{52, 62, 92, 142, 242, 542}, ret)
+	duration2 := stop.Sub(start)
+
+	// this may be reliable enough in all scenarios (CI vs local machine)
+	// the seq case shall be 10+20+50+100+200+500=880ms long
+	// the parallel one shall take slightly more than 500ms
+	require.GreaterOrEqual(t, duration1, duration2)
+}

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -29,6 +29,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// EmptyStdio is a good default which does not read neither prints anything from/to stdin/stdout/stderr
+var EmptyStdio = Stdio{
+	io.NopCloser(zeroReader{}),
+	io.Discard,
+	io.Discard,
+}
+
 // Stdio describes standard io streams for commands
 type Stdio struct {
 	Stdin  io.ReadCloser // TODO: is this needed?
@@ -194,3 +201,10 @@ type nopCloser struct {
 }
 
 func (nopCloser) Close() error { return nil }
+
+// zeroReader reads nothing from stdin and ends with io.EOF
+type zeroReader struct{}
+
+func (zeroReader) Read([]byte) (int, error) {
+	return 0, io.EOF
+}


### PR DESCRIPTION
 * add internal PMap function executing jobs capped by max active ones
 * changed the check logic, so files to be checked are first loaded
   into slice and then moved to PMap
 * code maintains the same ordering of results
 * drop ErrMismatch, this is not handled in collect phase after PMap is
   done with the work
 * adds several GNU options like --ignore-missing and --status
 * adds -j/--threads options controlling a concurrency (inspired by
   ripgrep)
 * improved test cases, but they're far from perfect
