### PR TITLE
[all] improve unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Unix text utilities implemented in pure Go and an excellent [github.com/benhoyt/
  * ✔ Busybox-like command line tool
  * ⚠ not yet guaranteed to be stable, API may change
 
+# Builtins
+
+ * cat -uses [goawk](https://github.com/benhoyt/goawk)
+ * cksum - POSIX ctx, md5 and sha check sums, runs concurrently (`-j/--threads`) by default
+ * head -n/--lines - uses [goawk](https://github.com/gomoni/gonix/blob/main/head/head_negative.awk)
+ * wc - word count
+
 # Go library
 
 Each tool can be called from Go code.
@@ -51,7 +58,7 @@ automatically like unix `sh(1)` do.
 	// 3
 ```
 
-## Flexible shell colon parsing and execution
+## Flexible shell colon parsing and command execution
 
 Most unix colons exists in shell compatible format. `gonix` provides helpers which can split the shell
 syntax into equivalent Go code. Code can
@@ -94,12 +101,74 @@ Can be built and executed like busybox or a toybox.
 ./gonix cat /etc/passwd /etc/resolv.conf | ./gonix cksum --algorithm md5 --untagged md5sum
 ```
 
-# Builtins
+# Architecture of commands
 
- * cat -uses [goawk](https://github.com/benhoyt/goawk)
- * cksum - POSIX ctx, md5 and sha check sums, runs concurrently (`-j/--threads`) by default
- * wc - word count
- * head -n/--lines - uses [goawk](https://github.com/gomoni/gonix/blob/main/head/head_negative.awk)
+1. Each command is represented as Go struct
+2. New() returns a pointer to zero structure, no default values are passed in
+3. Optional `FromArgs([]string)(*Struct, error)` provides cli parsing and implements defaults
+4. It does defer most of runtime errors to `Run` method
+5. `Run(context.Context, pipe.Stdio) error` method gets a _value receiver_ so it never changes the configuration
+
+```go
+// wc does nothing, as it has all zeroes - an equivalent of &wc.Wc{} or new(Wc)
+wc := wc.New()
+// wc gets Lines(true) Chars(true) Bytes(true)
+wc, err := wc.FromArgs(nil)
+// wc gets chars(false)
+wc.Chars(false)
+// wc is a value receiver, so never changes the configuration
+err = wc.Run(...)
+```
+
+## Internal helpers
+
+`internal.RunFiles` abstracts running a command over stdin (and) or list of
+files. Takes a care about opening and proper closing the files, does errors
+gracefully, so they do not cancel the code to run, but are propagated to caller
+properly. Supports a parallel execution of tasks via `internal.PMap` so `cksum`
+run in a parallel by default.
+
+`internal.PMap` is a parallel map algorithm. Executes MapFunc, which converts
+input slices to output slice and each execution is capped by maximum number of
+threads. It maintains the order.
+
+`internal.Unit` and `internal.Byte` is a fork of time.Duration of stdlib, which
+supports bigger ranges (based on float64). New units can be easily defined on
+top of Unit type.
+
+## Testing
+
+The typical testing is very repetitive, so there is a common structure for build of
+table tests. It uses generics to improve a type safety.
+
+```
+import "github.com/gomoni/gonix/internal/test"
+
+	testCases := []test.Case[Wc, *Wc]{
+		{
+			Name:     "wc -l",
+			Filter:   New().Lines(true),
+			FromArgs: fromArgs(t, []string{"-l"}),
+			Input:    "three\nsmall\npigs\n",
+			Expected: "3\n",
+		},
+    }
+	test.RunAll(t, testCases)
+```
+
+Where the struct fields are
+
+* Name is name of test case to be printed by go test
+* Input is a string input for a particular command
+* Expected is what command is supposed to generate
+* Filter is a definition of a filter
+* FromArgs is an alternative definition obtained by `FromArgs` helper. It
+  ensures CLI parsing is tested as a part of regular functional testing
+
+## Testing with real files
+
+WIP atm, there is `test.TestData` helper and a bunch of code in
+`cksum/cksum_test.go` to run tests using real files.
  
 # Other interesting projects
  * ♥ [github.com/benhoyt/goawk](https://github.com/benhoyt/goawk) an excellent awk implementation for Go

--- a/cat/cat.go
+++ b/cat/cat.go
@@ -62,7 +62,7 @@ func New() *Cat {
 	return &Cat{}
 }
 
-// FromArgs build a CatFilter from standard argv except the command name (os.Argv[1:])
+// FromArgs build a Cat from standard argv except the command name (os.Argv[1:])
 func (c *Cat) FromArgs(argv []string) (*Cat, error) {
 	flag := pflag.FlagSet{}
 
@@ -80,6 +80,12 @@ func (c *Cat) FromArgs(argv []string) (*Cat, error) {
 	// TODO FIXME - single dash options only - this accepts -e and --e
 	flag.BoolVarP(&e, "e", "e", false, "equivalent of -vE")
 	flag.BoolVarP(&t, "t", "t", false, "equivalent of -vT")
+
+	err := flag.Parse(argv)
+	if err != nil {
+		return nil, pipe.NewErrorf(1, "cat: parsing failed: %w", err)
+	}
+
 	if all {
 		c.ShowNonPrinting(true).ShowEnds(true).ShowTabs(true)
 	}
@@ -90,17 +96,15 @@ func (c *Cat) FromArgs(argv []string) (*Cat, error) {
 		c.ShowNonPrinting(true).ShowTabs(true)
 	}
 
-	err := flag.Parse(argv)
-	if err != nil {
-		return nil, pipe.NewErrorf(1, "cat: parsing failed: %w", err)
+	if len(flag.Args()) > 0 {
+		c.files = flag.Args()
 	}
-	c.files = flag.Args()
 
 	// post process
 	if *nb {
 		c.ShowNumber(NonBlank)
 	} else if *na {
-		c.ShowNumber(NonBlank)
+		c.ShowNumber(All)
 	}
 
 	return c, nil

--- a/cat/cat_test.go
+++ b/cat/cat_test.go
@@ -29,6 +29,7 @@ func TestCat(t *testing.T) {
 		{
 			Name:     "cat",
 			Filter:   New(),
+			FromArgs: fromArgs(t, nil),
 			Input:    "three\nsmall\npigs\n",
 			Expected: "three\nsmall\npigs\n",
 		},
@@ -36,6 +37,7 @@ func TestCat(t *testing.T) {
 		{
 			Name:     "cat -b",
 			Filter:   New().ShowNumber(NonBlank),
+			FromArgs: fromArgs(t, []string{"-b"}),
 			Input:    "three\n\n\nsmall\npigs\n",
 			Expected: "     1\tthree\n\n\n     2\tsmall\n     3\tpigs\n",
 		},
@@ -43,18 +45,21 @@ func TestCat(t *testing.T) {
 		{
 			Name:     "cat -E",
 			Filter:   New().ShowEnds(true),
+			FromArgs: fromArgs(t, []string{"-E"}),
 			Input:    "three\nsmall\npigs\n",
 			Expected: "three$\nsmall$\npigs$\n",
 		},
 		{
 			Name:     "cat -n",
 			Filter:   New().ShowNumber(All),
+			FromArgs: fromArgs(t, []string{"-n"}),
 			Input:    "three\nsmall\npigs\n",
 			Expected: "     1\tthree\n     2\tsmall\n     3\tpigs\n",
 		},
 		{
 			Name:     "cat -s",
 			Filter:   New().SqueezeBlanks(true),
+			FromArgs: fromArgs(t, []string{"-s"}),
 			Input:    "three\n\n\nsmall\npigs\n",
 			Expected: "three\n\nsmall\npigs\n",
 		},
@@ -62,23 +67,25 @@ func TestCat(t *testing.T) {
 		{
 			Name:     "cat -T",
 			Filter:   New().ShowTabs(true),
+			FromArgs: fromArgs(t, []string{"-T"}),
 			Input:    "\tthree\nsmall\t\npi\tgs\n",
 			Expected: "^Ithree\nsmall^I\npi^Igs\n",
 		},
 		{
 			Name:     "cat -ET",
 			Filter:   New().ShowEnds(true).ShowTabs(true),
+			FromArgs: fromArgs(t, []string{"-ET"}),
 			Input:    "\tthree\nsmall\t\npi\tgs\n",
 			Expected: "^Ithree$\nsmall^I$\npi^Igs$\n",
 		},
 		{
 			Name:     "cat -A",
 			Filter:   New().ShowNonPrinting(true).ShowEnds(true).ShowTabs(true),
+			FromArgs: fromArgs(t, []string{"-A"}),
 			Input:    string(rune(127)) + "\tthree\nsmall\t\npi\tgs\n",
 			Expected: "^?^Ithree$\nsmall^I$\npi^Igs$\n",
 		},
 	}
-
 	test.RunAll(t, testCases)
 }
 
@@ -152,4 +159,12 @@ func TestError(t *testing.T) {
 		require.Contains(t, e.Err.Error(), "main.c")
 	})
 
+}
+
+func fromArgs(t *testing.T, argv []string) *Cat {
+	t.Helper()
+	n := New()
+	f, err := n.FromArgs(argv)
+	require.NoError(t, err)
+	return f
 }

--- a/cksum/cksum_test.go
+++ b/cksum/cksum_test.go
@@ -20,25 +20,28 @@ func TestCKSum(t *testing.T) {
 	testCases := []test.Case[CKSum, *CKSum]{
 		{
 			Name:     "default",
-			Filter:   New(),
+			Filter:   fromArgs(t, nil),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "1340348198 27 \n",
 		},
 		{
 			Name:     "default untagged",
 			Filter:   New().Untagged(false),
+			FromArgs: fromArgs(t, nil),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "1340348198 27 \n",
 		},
 		{
 			Name:     "md5",
 			Filter:   New().Algorithm(MD5),
+			FromArgs: fromArgs(t, []string{"--algorithm", "md5"}),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "MD5 (-) = f4699b80440c0403b31fce987f9cd8af\n",
 		},
 		{
 			Name:     "md5 untagged",
 			Filter:   New().Algorithm(MD5).Untagged(true),
+			FromArgs: fromArgs(t, []string{"--algorithm", "md5", "--untagged"}),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "f4699b80440c0403b31fce987f9cd8af  -\n",
 		},
@@ -231,67 +234,10 @@ func TestCheck(t *testing.T) {
 
 }
 
-func TestFromArgs(t *testing.T) {
-	test.Parallel(t)
-	testCases := []struct {
-		name     string
-		args     []string
-		expected *CKSum
-	}{
-		{
-			"default",
-			nil,
-			New(),
-		},
-		{
-			"--check",
-			[]string{"--check"},
-			New().Check(true),
-		},
-		{
-			"--tag",
-			[]string{"--tag"},
-			New(),
-		},
-		{
-			"--algorithm crc",
-			[]string{"--algorithm", "crc"},
-			New().Algorithm(CRC).Untagged(true),
-		},
-		{
-			"--algorithm sha1",
-			[]string{"--algorithm", "sha1"},
-			New().Algorithm(SHA1),
-		},
-		{
-			"--algorithm blake2b --untagged",
-			[]string{"--algorithm", "blake2b", "--untagged"},
-			New().Algorithm(BLAKE2B).Untagged(true),
-		},
-		{
-			"--ignore-missing",
-			[]string{"--ignore-missing"},
-			New().IgnoreMissing(true),
-		},
-		{
-			"--quiet",
-			[]string{"--quiet"},
-			New().Quiet(true),
-		},
-		{
-			"--status",
-			[]string{"--status"},
-			New().Status(true),
-		},
-	}
-
-	for _, tt := range testCases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			test.Parallel(t)
-			cksum, err := New().FromArgs(tt.args)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, cksum)
-		})
-	}
+func fromArgs(t *testing.T, argv []string) *CKSum {
+	t.Helper()
+	n := New()
+	f, err := n.FromArgs(argv)
+	require.NoError(t, err)
+	return f
 }

--- a/head/head.go
+++ b/head/head.go
@@ -33,15 +33,15 @@ type Head struct {
 }
 
 func New() *Head {
-	return &Head{
-		debug:          false,
-		lines:          10,
-		zeroTerminated: false,
-		files:          []string{},
-	}
+	return &Head{}
 }
 
 func (c *Head) FromArgs(argv []string) (*Head, error) {
+	if len(argv) == 0 {
+		c = c.Lines(10)
+		return c, nil
+	}
+
 	flag := pflag.FlagSet{}
 
 	var lines internal.Byte = internal.Byte(c.lines)
@@ -53,7 +53,9 @@ func (c *Head) FromArgs(argv []string) (*Head, error) {
 	if err != nil {
 		return nil, pipe.NewErrorf(1, "head: parsing failed: %w", err)
 	}
-	c.files = flag.Args()
+	if len(flag.Args()) > 0 {
+		c.files = flag.Args()
+	}
 
 	// TODO: deal with more than int64 lines
 	c.lines = int(math.Round(float64(lines)))

--- a/head/head_test.go
+++ b/head/head_test.go
@@ -17,64 +17,39 @@ func TestHead(t *testing.T) {
 	testCases := []test.Case[Head, *Head]{
 		{
 			Name:     "default",
-			Filter:   New(),
+			Filter:   fromArgs(t, []string{}),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n",
 		},
 		{
 			Name:     "--lines 2",
 			Filter:   New().Lines(2),
+			FromArgs: fromArgs(t, []string{"-n", "2"}),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "1\n2\n",
 		},
 		{
 			Name:     "--lines -10",
 			Filter:   New().Lines(-10),
+			FromArgs: fromArgs(t, []string{"-n", "-10"}),
 			Input:    "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n",
 			Expected: "1\n2\n",
 		},
 		{
 			Name:     "--lines 2 --zero-terminated",
 			Filter:   New().Lines(2).ZeroTerminated(true),
+			FromArgs: fromArgs(t, []string{"-n", "2", "--zero-terminated"}),
 			Input:    "1\x002\x003\x004\x00",
 			Expected: "1\n2\n",
 		},
 	}
-
 	test.RunAll(t, testCases)
 }
 
-func TestFromArgs(t *testing.T) {
-	test.Parallel(t)
-	testCases := []struct {
-		name     string
-		args     []string
-		expected *Head
-	}{
-		{
-			"default",
-			nil,
-			New(),
-		},
-		{
-			"lines",
-			[]string{"--lines", "10KiB"},
-			New().Lines(10240),
-		},
-		{
-			"zero terminated",
-			[]string{"--zero-terminated"},
-			New().ZeroTerminated(true),
-		},
-	}
-
-	for _, tt := range testCases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			test.Parallel(t)
-			head, err := New().FromArgs(tt.args)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, head)
-		})
-	}
+func fromArgs(t *testing.T, argv []string) *Head {
+	t.Helper()
+	n := New()
+	f, err := n.FromArgs(argv)
+	require.NoError(t, err)
+	return f
 }

--- a/wc/wc.go
+++ b/wc/wc.go
@@ -71,6 +71,9 @@ func (c *Wc) FromArgs(argv []string) (*Wc, error) {
 	if err != nil {
 		return nil, pipe.NewErrorf(1, "wc: parsing failed: %w", err)
 	}
+	if len(flag.Args()) > 0 {
+		c.files = flag.Args()
+	}
 
 	return c, nil
 }


### PR DESCRIPTION
Add `FromArgs` into test case, so CLI parsing is tested together with
regulat unit tests. Clean up, unify and document the expected behavior
of `New()` functions across implemented code.
