### PR TITLE
[wasm/gen] drop arguments, add a support for []string type

### DIFF
--- a/sbase/tr/tr.go
+++ b/sbase/tr/tr.go
@@ -41,31 +41,31 @@ func New() *Tr {
 	return &Tr{}
 }
 
-// Complement: Match to set1 complement
+// Complement: set Match to set1 complement(s)
 func (c *Tr) Complement(x bool) *Tr {
 	c.complement = x
 	return c
 }
 
-// Delete: Delete characters matching
+// Delete: set Delete characters matching(s)
 func (c *Tr) Delete(x bool) *Tr {
 	c._delete = x
 	return c
 }
 
-// Squeeze: Squeeze repeated characters matching set1 or set2
+// Squeeze: set Squeeze repeated characters matching set1 or set2(s)
 func (c *Tr) Squeeze(x bool) *Tr {
 	c.squeeze = x
 	return c
 }
 
-// Set1: Define set1
+// Set1: set Define set1(s)
 func (c *Tr) Set1(x string) *Tr {
 	c.set1 = x
 	return c
 }
 
-// Set2: Define set2
+// Set2: set Define set2(s)
 func (c *Tr) Set2(x string) *Tr {
 	c.set2 = x
 	return c

--- a/sbase/tr/tr.yaml
+++ b/sbase/tr/tr.yaml
@@ -6,15 +6,16 @@ options:
     name: Complement
     type: bool
     cli: -c
-  - text: Delete characters matching
+  - 
+    text: Delete characters matching
     name: Delete
     type: bool
     cli: -d
-  - text: Squeeze repeated characters matching set1 or set2
+  - 
+    text: Squeeze repeated characters matching set1 or set2
     name: Squeeze
     type: bool
     cli: -s
-arguments:
   -
     text: Define set1
     name: Set1


### PR DESCRIPTION
Removes a duplicity in the code, the template checks for `ne .CLI ""`
now.
