### PR TITLE
Problem: pointer heavy code

### DIFF
--- a/cat/cat.go
+++ b/cat/cat.go
@@ -59,12 +59,13 @@ type Cat struct {
 	showNonPrinting bool
 }
 
-func New() *Cat {
-	return &Cat{}
+func New() Cat {
+	return Cat{}
 }
 
 // FromArgs build a Cat from standard argv except the command name (os.Argv[1:])
-func (c *Cat) FromArgs(argv []string) (*Cat, error) {
+func (c Cat) FromArgs(argv []string) (Cat, error) {
+	var zero Cat
 	flag := pflag.FlagSet{}
 
 	nb := flag.BoolP("number-nonblank", "b", false, "number non blank lines only")
@@ -84,7 +85,7 @@ func (c *Cat) FromArgs(argv []string) (*Cat, error) {
 
 	err := flag.Parse(argv)
 	if err != nil {
-		return nil, pipe.NewErrorf(1, "cat: parsing failed: %w", err)
+		return zero, pipe.NewErrorf(1, "cat: parsing failed: %w", err)
 	}
 
 	if all {
@@ -112,43 +113,43 @@ func (c *Cat) FromArgs(argv []string) (*Cat, error) {
 }
 
 // Files are input files, where - denotes stdin
-func (c *Cat) Files(f ...string) *Cat {
+func (c Cat) Files(f ...string) Cat {
 	c.files = append(c.files, f...)
 	return c
 }
 
 // ShowNumber adds none all or non empty output lines
-func (c *Cat) ShowNumber(n number) *Cat {
+func (c Cat) ShowNumber(n number) Cat {
 	c.showNumber = n
 	return c
 }
 
 // ShowEnds add $ to the end of each line
-func (c *Cat) ShowEnds(b bool) *Cat {
+func (c Cat) ShowEnds(b bool) Cat {
 	c.showEnds = b
 	return c
 }
 
 // SqueezeBlanks - supress repeated empty lines
-func (c *Cat) SqueezeBlanks(b bool) *Cat {
+func (c Cat) SqueezeBlanks(b bool) Cat {
 	c.squeezeBlanks = b
 	return c
 }
 
 // ShowTabs display TAB as ^I
-func (c *Cat) ShowTabs(b bool) *Cat {
+func (c Cat) ShowTabs(b bool) Cat {
 	c.showTabs = b
 	return c
 }
 
 // ShowNonPrinting use ^ and M- notation, except for LFD and TAB
-func (c *Cat) ShowNonPrinting(b bool) *Cat {
+func (c Cat) ShowNonPrinting(b bool) Cat {
 	c.showNonPrinting = b
 	return c
 }
 
 // SetDebug additional debugging messages on stderr
-func (c *Cat) SetDebug(debug bool) *Cat {
+func (c Cat) SetDebug(debug bool) Cat {
 	c.debug = debug
 	return c
 }

--- a/cat/cat_test.go
+++ b/cat/cat_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 func TestCat(t *testing.T) {
 	test.Parallel(t)
 
-	testCases := []test.Case[Cat, *Cat]{
+	testCases := []test.Case[Cat]{
 		{
 			Name:     "cat",
 			Filter:   New(),
@@ -164,7 +164,7 @@ func TestError(t *testing.T) {
 
 }
 
-func fromArgs(t *testing.T, argv []string) *Cat {
+func fromArgs(t *testing.T, argv []string) Cat {
 	t.Helper()
 	n := New()
 	f, err := n.FromArgs(argv)

--- a/cksum/cksum.go
+++ b/cksum/cksum.go
@@ -139,56 +139,56 @@ type CKSum struct {
 	files         []string
 }
 
-func New() *CKSum {
-	return &CKSum{}
+func New() CKSum {
+	return CKSum{}
 }
 
 // Files are input files, where - denotes stdin
-func (c *CKSum) Files(f ...string) *CKSum {
+func (c CKSum) Files(f ...string) CKSum {
 	c.files = append(c.files, f...)
 	return c
 }
 
-func (c *CKSum) Algorithm(algorithm Algorithm) *CKSum {
+func (c CKSum) Algorithm(algorithm Algorithm) CKSum {
 	c.algorithm = algorithm
 	return c
 }
 
-func (c *CKSum) Check(check bool) *CKSum {
+func (c CKSum) Check(check bool) CKSum {
 	c.check = true
 	return c
 }
 
-func (c *CKSum) IgnoreMissing(ignoreMissing bool) *CKSum {
+func (c CKSum) IgnoreMissing(ignoreMissing bool) CKSum {
 	c.ignoreMissing = ignoreMissing
 	return c
 }
 
-func (c *CKSum) Parallel(limit uint) *CKSum {
+func (c CKSum) Parallel(limit uint) CKSum {
 	c.threads = limit
 	return c
 }
 
-func (c *CKSum) Quiet(quiet bool) *CKSum {
+func (c CKSum) Quiet(quiet bool) CKSum {
 	c.quiet = quiet
 	return c
 }
 
-func (c *CKSum) Untagged(untagged bool) *CKSum {
+func (c CKSum) Untagged(untagged bool) CKSum {
 	c.untagged = untagged
 	return c
 }
 
-func (c *CKSum) Status(status bool) *CKSum {
+func (c CKSum) Status(status bool) CKSum {
 	c.status = status
 	return c
 }
-func (c *CKSum) SetDebug(debug bool) *CKSum {
+func (c CKSum) SetDebug(debug bool) CKSum {
 	c.debug = debug
 	return c
 }
 
-func (c *CKSum) FromArgs(argv []string) (*CKSum, error) {
+func (c CKSum) FromArgs(argv []string) (CKSum, error) {
 	flag := pflag.FlagSet{}
 	var algorithm Algorithm = NONE
 	flag.VarP(&algorithm, "algorithm", "a", "checksum algorithm to use, crc is default")
@@ -205,7 +205,7 @@ func (c *CKSum) FromArgs(argv []string) (*CKSum, error) {
 	flag.UintVarP(&threads, "threads", "j", 0, "generate or check using N goroutines, 0 equals GOMAXPROCS")
 	err := flag.Parse(argv)
 	if err != nil {
-		return nil, pipe.NewErrorf(1, "cksum: parsing failed: %w", err)
+		return CKSum{}, pipe.NewErrorf(1, "cksum: parsing failed: %w", err)
 	}
 
 	if len(flag.Args()) > 0 {

--- a/cksum/cksum_test.go
+++ b/cksum/cksum_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCKSum(t *testing.T) {
 	test.Parallel(t)
-	testCases := []test.Case[CKSum, *CKSum]{
+	testCases := []test.Case[CKSum]{
 		{
 			Name:     "default",
 			Filter:   fromArgs(t, nil),
@@ -126,7 +126,7 @@ func TestCheck(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		cksum          *CKSum
+		cksum          CKSum
 		expectedStdout string
 	}{
 		{
@@ -187,7 +187,7 @@ func TestCheck(t *testing.T) {
 	// test errors
 	errCases := []struct {
 		name           string
-		cksum          *CKSum
+		cksum          CKSum
 		expectedError  string
 		expectedStdout string
 	}{
@@ -252,7 +252,7 @@ func TestCheck(t *testing.T) {
 
 }
 
-func fromArgs(t *testing.T, argv []string) *CKSum {
+func fromArgs(t *testing.T, argv []string) CKSum {
 	t.Helper()
 	n := New()
 	f, err := n.FromArgs(argv)

--- a/head/head.go
+++ b/head/head.go
@@ -33,11 +33,11 @@ type Head struct {
 	files          []string
 }
 
-func New() *Head {
-	return &Head{}
+func New() Head {
+	return Head{}
 }
 
-func (c *Head) FromArgs(argv []string) (*Head, error) {
+func (c Head) FromArgs(argv []string) (Head, error) {
 	if len(argv) == 0 {
 		c = c.Lines(10)
 		return c, nil
@@ -52,7 +52,7 @@ func (c *Head) FromArgs(argv []string) (*Head, error) {
 
 	err := flag.Parse(argv)
 	if err != nil {
-		return nil, pipe.NewErrorf(1, "head: parsing failed: %w", err)
+		return Head{}, pipe.NewErrorf(1, "head: parsing failed: %w", err)
 	}
 	if len(flag.Args()) > 0 {
 		c.files = flag.Args()
@@ -66,22 +66,22 @@ func (c *Head) FromArgs(argv []string) (*Head, error) {
 }
 
 // Files are input files, where - denotes stdin
-func (c *Head) Files(f ...string) *Head {
+func (c Head) Files(f ...string) Head {
 	c.files = append(c.files, f...)
 	return c
 }
 
-func (c *Head) Lines(lines int) *Head {
+func (c Head) Lines(lines int) Head {
 	c.lines = lines
 	return c
 }
 
-func (c *Head) ZeroTerminated(zeroTerminated bool) *Head {
+func (c Head) ZeroTerminated(zeroTerminated bool) Head {
 	c.zeroTerminated = zeroTerminated
 	return c
 }
 
-func (c *Head) SetDebug(debug bool) *Head {
+func (c Head) SetDebug(debug bool) Head {
 	c.debug = debug
 	return c
 }

--- a/head/head_test.go
+++ b/head/head_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestHead(t *testing.T) {
 	test.Parallel(t)
-	testCases := []test.Case[Head, *Head]{
+	testCases := []test.Case[Head]{
 		{
 			Name:     "default",
 			Filter:   fromArgs(t, []string{}),
@@ -46,7 +46,7 @@ func TestHead(t *testing.T) {
 	test.RunAll(t, testCases)
 }
 
-func fromArgs(t *testing.T, argv []string) *Head {
+func fromArgs(t *testing.T, argv []string) Head {
 	t.Helper()
 	n := New()
 	f, err := n.FromArgs(argv)

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -30,15 +30,15 @@ func Parallel(t *testing.T) {
 
 // Case is a single test case testing gonix filter
 // It contains a pointer (PF) to type implementing the pipe.Filter interface
-type Case[F unix.Filter, PF interface{ *F }] struct {
+type Case[F unix.Filter] struct {
 	Name     string // Name is test case name
 	Input    string // Input is test case input
 	Expected string // Expected is what filter is expected to produce
-	Filter   PF     // Filter is a pointer to type implementing the pipe.Filter
-	FromArgs PF     // Optional Filter constructed via FromArgs helper, expected to be equal to Filter
+	Filter   F      // Filter is a pointer to type implementing the pipe.Filter
+	FromArgs F      // Optional Filter constructed via FromArgs helper, expected to be equal to Filter
 }
 
-func RunAll[F unix.Filter, PF interface{ *F }](t *testing.T, testCases []Case[F, PF]) {
+func RunAll[F unix.Filter](t *testing.T, testCases []Case[F]) {
 	t.Helper()
 
 	for _, tt := range testCases {
@@ -54,7 +54,8 @@ func RunAll[F unix.Filter, PF interface{ *F }](t *testing.T, testCases []Case[F,
 			)
 			ctx := context.Background()
 
-			if tt.FromArgs != nil {
+			var zero F
+			if !reflect.DeepEqual(tt.FromArgs, zero) {
 				require.Equal(t, tt.FromArgs, tt.Filter)
 			}
 
@@ -65,7 +66,7 @@ func RunAll[F unix.Filter, PF interface{ *F }](t *testing.T, testCases []Case[F,
 				setDebug.Call([]reflect.Value{reflect.ValueOf(testing.Verbose())})
 			}
 
-			err := unix.NewLine().Run(ctx, stdio, *tt.Filter)
+			err := unix.NewLine().Run(ctx, stdio, tt.Filter)
 			require.NoError(t, err)
 			require.Equal(t, tt.Expected, out.String())
 		})

--- a/wc/wc.go
+++ b/wc/wc.go
@@ -2,6 +2,22 @@
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
+/*
+   Print  newline,  word, and byte counts for each FILE, and a total line if more than one FILE is specified.  A word is a non-zero-length sequence of printable characters delimited
+   by white space.
+
+   With no FILE, or when FILE is -, read standard input.
+
+   The options below may be used to select which counts are printed, always in the following order: newline, word, character, byte, maximum line length.
+
+   --files0-from=F
+          read input from the files specified by NUL-terminated names in file F; If F is - then read names from standard input
+
+   --version
+          output version information and exit
+
+*/
+
 package wc
 
 import (
@@ -24,22 +40,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-/*
-   Print  newline,  word, and byte counts for each FILE, and a total line if more than one FILE is specified.  A word is a non-zero-length sequence of printable characters delimited
-   by white space.
-
-   With no FILE, or when FILE is -, read standard input.
-
-   The options below may be used to select which counts are printed, always in the following order: newline, word, character, byte, maximum line length.
-
-   --files0-from=F
-          read input from the files specified by NUL-terminated names in file F; If F is - then read names from standard input
-
-   --version
-          output version information and exit
-
-*/
-
 type Wc struct {
 	debug         bool
 	bytes         bool
@@ -50,12 +50,12 @@ type Wc struct {
 	files         []string
 }
 
-func New() *Wc {
-	return &Wc{}
+func New() Wc {
+	return Wc{}
 }
 
 // FromArgs builds a WcFilter from standard argv except the command name (os.Argv[1:])
-func (c *Wc) FromArgs(argv []string) (*Wc, error) {
+func (c Wc) FromArgs(argv []string) (Wc, error) {
 	if len(argv) == 0 {
 		c = c.Bytes(true).Lines(true).Words(true)
 		return c, nil
@@ -70,7 +70,7 @@ func (c *Wc) FromArgs(argv []string) (*Wc, error) {
 
 	err := flag.Parse(argv)
 	if err != nil {
-		return nil, pipe.NewErrorf(1, "wc: parsing failed: %w", err)
+		return Wc{}, pipe.NewErrorf(1, "wc: parsing failed: %w", err)
 	}
 	if len(flag.Args()) > 0 {
 		c.files = flag.Args()
@@ -79,38 +79,38 @@ func (c *Wc) FromArgs(argv []string) (*Wc, error) {
 	return c, nil
 }
 
-func (w *Wc) Bytes(b bool) *Wc {
+func (w Wc) Bytes(b bool) Wc {
 	w.bytes = b
 	return w
 }
 
-func (w *Wc) Chars(b bool) *Wc {
+func (w Wc) Chars(b bool) Wc {
 	w.chars = b
 	return w
 }
 
-func (w *Wc) Lines(lines bool) *Wc {
+func (w Wc) Lines(lines bool) Wc {
 	w.lines = lines
 	return w
 }
 
-func (w *Wc) MaxLineLength(b bool) *Wc {
+func (w Wc) MaxLineLength(b bool) Wc {
 	w.maxLineLength = b
 	return w
 }
 
-func (w *Wc) Words(b bool) *Wc {
+func (w Wc) Words(b bool) Wc {
 	w.words = b
 	return w
 }
 
 // Files adds files into a list of files
-func (w *Wc) Files(files ...string) *Wc {
+func (w Wc) Files(files ...string) Wc {
 	w.files = append(w.files, files...)
 	return w
 }
 
-func (w *Wc) SetDebug(debug bool) *Wc {
+func (w Wc) SetDebug(debug bool) Wc {
 	w.debug = debug
 	return w
 }

--- a/wc/wc_test.go
+++ b/wc/wc_test.go
@@ -17,7 +17,7 @@ import (
 func TestWc(t *testing.T) {
 	test.Parallel(t)
 	threeSmallPigs := test.Testdata(t, "three-small-pigs")
-	testCases := []test.Case[Wc, *Wc]{
+	testCases := []test.Case[Wc]{
 		{
 			Name:     "default",
 			Filter:   fromArgs(t, []string{}),
@@ -57,7 +57,7 @@ func TestWc(t *testing.T) {
 	test.RunAll(t, testCases)
 }
 
-func fromArgs(t *testing.T, argv []string) *Wc {
+func fromArgs(t *testing.T, argv []string) Wc {
 	t.Helper()
 	n := New()
 	f, err := n.FromArgs(argv)

--- a/x/tr/tr.go
+++ b/x/tr/tr.go
@@ -70,26 +70,26 @@ type Tr struct {
 	files []string
 }
 
-func New() *Tr {
-	return &Tr{}
+func New() Tr {
+	return Tr{}
 }
 
-func (c *Tr) Array1(in string) *Tr {
+func (c Tr) Array1(in string) Tr {
 	c.array1 = in
 	return c
 }
 
-func (c *Tr) Array2(in string) *Tr {
+func (c Tr) Array2(in string) Tr {
 	c.array2 = in
 	return c
 }
 
-func (c *Tr) Complement(b bool) *Tr {
+func (c Tr) Complement(b bool) Tr {
 	c.complement = b
 	return c
 }
 
-func (c *Tr) Delete(b bool) *Tr {
+func (c Tr) Delete(b bool) Tr {
 	c.del = b
 	return c
 }

--- a/x/tr/tr_test.go
+++ b/x/tr/tr_test.go
@@ -13,7 +13,7 @@ func TestMain(m *testing.M) {
 
 func TestTr(t *testing.T) {
 	test.Parallel(t)
-	testCases := []test.Case[Tr, *Tr]{
+	testCases := []test.Case[Tr]{
 		{
 			Name:     "tr -d aeiou",
 			Filter:   New().Array1("aeiou").Delete(true),


### PR DESCRIPTION
Solution: pass the struct and return a copy when configuring. Simplify the internal testing helpers and make code more idiomatic.